### PR TITLE
add: .claude/skills/ for Claude Code project skills

### DIFF
--- a/.claude/skills/add-design-md.md
+++ b/.claude/skills/add-design-md.md
@@ -1,0 +1,42 @@
+# Add DESIGN.md for a Japanese Web Service
+
+## When to use
+When the user wants to add a new Japanese web service's DESIGN.md to this collection.
+
+## Workflow
+
+1. **Identify the target service** — Get the service name and URL from the user.
+
+2. **Check for duplicates** — Verify the service doesn't already exist under `design-md/`.
+
+3. **Analyze the site's CSS** — Use the site URL to extract:
+   - Color palette (hex values from computed styles)
+   - Font-family declarations (especially CJK font stacks)
+   - Typography tokens (size, weight, line-height, letter-spacing)
+   - Component styles (buttons, inputs, cards)
+   - Layout values (max-width, spacing, grid)
+   - Responsive breakpoints
+
+4. **Create the DESIGN.md** — Copy `template/DESIGN.md` to `design-md/<service-name>/DESIGN.md` and fill in all 9 sections:
+   1. Visual Theme & Atmosphere
+   2. Color Palette & Roles
+   3. Typography Rules (sections 3.1-3.8 — the core of Japanese typography)
+   4. Component Stylings
+   5. Layout Principles
+   6. Depth & Elevation
+   7. Do's and Don'ts
+   8. Responsive Behavior
+   9. Agent Prompt Guide
+
+5. **Create preview.html** — Generate a `design-md/<service-name>/preview.html` that visualizes the extracted design tokens. Follow the same structure as existing preview files (e.g., `design-md/apple/preview.html`).
+
+6. **Update README.md** — Add the new service to the "Included Sites" table in README.md, in the appropriate position.
+
+## Important rules
+- Service directory name: lowercase romaji, no hyphens (e.g., `smarthr` not `smart-hr`)
+- Section headers: English (for AI agent readability)
+- Value descriptions and Do's/Don'ts: Japanese
+- All color values must be exact hex from computed styles, not guesses
+- font-family must include the full fallback chain
+- line-height, letter-spacing must be measured values
+- Commit message format: `add: <service-name> DESIGN.md`

--- a/.claude/skills/generate-preview.md
+++ b/.claude/skills/generate-preview.md
@@ -1,0 +1,30 @@
+# Generate Preview HTML
+
+## When to use
+When the user wants to create or regenerate a `preview.html` file for a DESIGN.md.
+
+## Workflow
+
+1. **Read the DESIGN.md** — Parse all design tokens from the target service's DESIGN.md file.
+
+2. **Generate preview.html** — Create an HTML file that showcases:
+   - Color palette swatches with hex labels
+   - Typography scale (Display through Small, showing actual fonts)
+   - Japanese text samples demonstrating line-height and letter-spacing
+   - Component examples (buttons, inputs, cards)
+   - Spacing scale visualization
+   - Elevation/shadow examples
+
+3. **Follow existing conventions** — Match the structure and style of existing preview files in the repo (e.g., `design-md/apple/preview.html`):
+   - `lang="ja"` on the html element
+   - CSS custom properties for all design tokens
+   - Self-contained (no external dependencies)
+   - Responsive layout
+
+4. **Output** — Write to `design-md/<service-name>/preview.html`
+
+## Key points
+- Use actual Japanese text samples (not lorem ipsum) to demonstrate typography
+- Include mixed Japanese-Latin text to show mixed typesetting (konshoku) behavior
+- Show kinsoku shori behavior with punctuation examples
+- Ensure the preview renders correctly in modern browsers

--- a/.claude/skills/validate-design-md.md
+++ b/.claude/skills/validate-design-md.md
@@ -1,0 +1,28 @@
+# Validate DESIGN.md Quality
+
+## When to use
+When the user wants to review or validate an existing DESIGN.md file for quality and completeness.
+
+## Checklist
+
+### Required (must pass)
+- [ ] font-family fallback chain is accurate and complete (CJK font first)
+- [ ] All colors are exact hex values (no named colors, no guesses)
+- [ ] line-height and letter-spacing are measured values from the actual site
+- [ ] Section headers are in English
+- [ ] Value descriptions and Do's/Don'ts are in Japanese
+- [ ] All 9 sections are present
+- [ ] Typography section 3.1-3.8 subsections are filled in
+- [ ] Agent Prompt Guide (section 9) has a valid quick reference block
+
+### Recommended
+- [ ] References official design system documentation if available
+- [ ] Consistent values across multiple pages
+- [ ] Light mode and dark mode covered (if the service supports both)
+- [ ] preview.html exists and matches the DESIGN.md tokens
+
+## How to validate
+1. Read the target DESIGN.md file
+2. Check each item in the checklist above
+3. If possible, fetch the actual site CSS to compare values
+4. Report findings with specific line numbers and suggested fixes

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 scripts/
 package.json
 package-lock.json
-.claude/
+.claude/*
+!.claude/skills/
 CLAUDE.md
 .DS_Store


### PR DESCRIPTION
## Summary
- Add `.claude/skills/` directory with three Claude Code project skills:
  - **add-design-md**: Workflow for adding new Japanese service DESIGN.md
  - **validate-design-md**: Quality validation checklist for DESIGN.md files
  - **generate-preview**: Preview HTML generation from design tokens
- Update `.gitignore` to track `.claude/skills/` while keeping other `.claude/` files ignored

## Test plan
- [ ] Verify `.claude/skills/` files are tracked in git
- [ ] Verify other `.claude/` files (settings, etc.) are still ignored
- [ ] Test skills work with Claude Code in the project directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)