### PR TITLE
Add: xecin.jp

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Without these specifications, AI agents produce Japanese UI with broken typograp
 | [visvim (ビズビム)](https://www.visvim.tv/) | Fashion / Premium Lifestyle | [DESIGN.md](design-md/visvim/DESIGN.md) | [preview.html](design-md/visvim/preview.html) |
 | [NEIGHBORHOOD (ネイバーフッド)](https://www.neighborhood.jp/) | Fashion / Streetwear | [DESIGN.md](design-md/neighborhood/DESIGN.md) | [preview.html](design-md/neighborhood/preview.html) |
 | [Afternoon Tea (アフタヌーンティー)](https://www.afternoon-tea.net/) | Lifestyle / Retail | [DESIGN.md](design-md/afternoontea/DESIGN.md) | [preview.html](design-md/afternoontea/preview.html) |
+| [XECIN](https://xecin.jp/) | Web Development Lab | [DESIGN.md](design-md/xecin/DESIGN.md) | [preview.html](design-md/xecin/preview.html) |
 
 ### Previews
 

--- a/design-md/xecin/DESIGN.md
+++ b/design-md/xecin/DESIGN.md
@@ -1,0 +1,370 @@
+# DESIGN.md — XECIN
+
+> XECIN（https://xecin.jp/）のデザイン仕様書。
+> AIエージェントが正確な日本語UIを生成するためのデザイン仕様書です。
+> セクションヘッダーは英語、値の説明は日本語で記述しています。
+> 実サイトのグローバル CSS（Astro でバンドルされる `:root` CSS カスタムプロパティ）に基づく実測値。
+
+---
+
+## 1. Visual Theme & Atmosphere
+
+- **デザイン方針**: シャープ・ダーク・モダン。装飾を排したミニマルな黒基調コーポレートデザイン。深みのある暗色と鮮やかなクリムゾン（深紅）グラデーションのコントラストで、技術力と信頼感を表現
+- **密度**: セクション単位で余白を大きく取った低密度レイアウト。情報は絞り込まれており、コンテンツの見通しが良い
+- **キーワード**: 鋭利、暗色、プロフェッショナル、緊張感、技術主導
+- **特徴**:
+  - ヒーローは超暗色（`#0c0408`）背景に写真をオーバーレイ。ライトセクションは純白 `#fff` または微かなローズがかった `#faf3f6`
+  - ブランドカラーはクリムゾン系グラデーション（`#b82048` → `#d03060`）
+  - ボタン・CTA の角丸は **0（シャープエッジ）** — ブランドの最も特徴的なデザイン判断
+  - 表示フォント（Barlow Condensed）と和文フォント（Noto Sans JP）を明確に使い分け
+
+---
+
+## 2. Color Palette & Roles
+
+<!-- 実サイト `:root` CSS カスタムプロパティから直接取得 -->
+
+### Primary（ブランドカラー）
+
+- **Crimson** (`#b82048`): ブランドグラデーション開始色（`--gd`）。ボタン・アクセントライン・ホバー効果・アイコンに使用
+- **Rose** (`#d03060`): ブランドグラデーション終了色（`--gd2`）。CTA ボタン・見出しアクセントに使用
+- **Light Rose** (`#e04878`): ブランドカラーのライト版（`--gd3`）。グラデーション内の明るい段階
+
+### Dark（ダーク系）
+
+- **Ink** (`#0c0408`): 本文テキスト・ナビ背景（`--ink`）。純粋な黒ではなく深いパープルがかった黒
+- **Deep Ink** (`#1e0814`): ヒーロー背景・フッター背景（`--ink2`）。より深いダーク
+
+### Neutral Muted（ミュート系）
+
+- **Mauve** (`#705060`): 補足テキスト・説明文（`--tm`）。ローズがかったグレー
+- **Dark Mauve** (`#4a3040`): より濃いセカンダリテキスト（`--ts`）
+
+### Background Scale
+
+- **White** (`#ffffff`): メインページ背景（`--bg`）
+- **Rose 50** (`#faf3f6`): サービス/ケース等ライトセクション背景（`--bg2`）
+- **Rose 100** (`#f2e6ec`): カード間ギャップ・区切り（`--bg3`）
+- **Rose 200** (`#ead8e0`): より濃いサーフェス（`--bg4`）
+
+### Border
+
+- **Brand Border** (`rgba(184, 32, 72, 0.15)`): セクション区切り・カードボーダー（`--bd` = `#b8204826`）
+- **Subtle Border** (`rgba(184, 32, 72, 0.07)`): 微細区切り（`--bds` = `#b8204812`）
+
+---
+
+## 3. Typography Rules
+
+<!-- Google Fonts 経由で読み込み。font-family 指定はサイト CSS に基づく -->
+
+### 3.1 和文フォント
+
+- **ゴシック体**: Noto Sans JP（Google Fonts）。ウェイト 300/400/500/700/900 を読み込み
+- 明朝体: 使用なし
+
+### 3.2 欧文フォント
+
+- **コンデンスドサンセリフ（表示用）**: Barlow Condensed（Google Fonts）。ウェイト 400/600/700/800/900 を読み込み
+- **等幅**: 未使用（プロダクトUIなし）
+
+### 3.3 font-family 指定
+
+```css
+/* 和文本文・説明文 */
+font-family: "Noto Sans JP", sans-serif;   /* --font-body */
+
+/* ロゴ・見出し・ラベル・CTA ボタン（英数字主体の表示用） */
+font-family: "Barlow Condensed", sans-serif;  /* --font-display */
+```
+
+**フォールバックの考え方**:
+- 和文本文は Noto Sans JP + sans-serif フォールバック（Noto が読み込めない環境でもシステム和文フォントに切り替わる）
+- 表示フォント（Barlow Condensed）は英数字・大文字ラベル専用。和文には使わない
+- ロゴ文字列「XECIN」は Barlow Condensed + font-weight 900 が正確な指定
+
+### 3.4 文字サイズ・ウェイト階層
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | 備考 |
+|------|------|------|--------|-------------|----------------|------|
+| Hero H1 | Barlow Condensed | clamp(40px, 9vw, 120px) | 900 | 0.95 | — | ヒーロー大見出し（超タイト） |
+| Section Display | Barlow Condensed | clamp(48px, 7vw, 88px) | 900 | 1.0 | -0.01em | セクション英語タイトル |
+| CTA Heading | Barlow Condensed | clamp(36px, 6vw, 72px) | 900 | 1.05 | -0.01em | CTAセクション見出し |
+| Band H2 | Barlow Condensed | clamp(28px, 4.5vw, 56px) | 900 | 1.1 | -0.01em | フォトバンド見出し |
+| Step Title | Noto Sans JP | 20px | 900 | — | -0.01em | ステップ・実績見出し |
+| FAQ / Body H3 | Noto Sans JP | 15px | 700 | 1.5 | — | FAQ 質問・中見出し |
+| Body | Noto Sans JP | 13–14px | 300 | 1.85–1.9 | — | 説明文・本文 |
+| Caption / Small | Noto Sans JP | 12–13px | 300–400 | — | 0.07–0.08em | ナビリンク・補足 |
+| Label / Eyebrow | Barlow Condensed | 10–12px | 700 | — | 0.16–0.22em | 大文字ラベル・タグ |
+
+### 3.5 行間・字間
+
+- **本文の行間 (line-height)**: `1.85〜1.9`（日本語説明文・カード本文）
+- **見出しの行間（英語コンデンスド）**: `0.95〜1.1`（超タイト。英語大文字表示専用）
+- **本文の字間 (letter-spacing)**: `0.07〜0.08em`（日本語本文・ナビリンク）
+- **ラベル・アイブロウの字間**: `0.16〜0.22em`（大文字英字ラベル）
+- **見出し letter-spacing**: `-0.01em`（軽く詰める）
+
+**ガイドライン**:
+- 日本語本文 `line-height: 1.85` 以上で可読性を確保（このサイトの標準）
+- Barlow Condensed の `letter-spacing: 0.16em+` は大文字ラベル専用設定。和文に適用しないこと
+- 本文 font-weight 300 は Noto Sans JP の Light ウェイト。細身で洗練された印象
+
+### 3.6 禁則処理・改行ルール
+
+```css
+/* サイトで観測されたスタイル */
+overflow-x: hidden;  /* 横スクロール防止 */
+```
+
+- 禁則処理の明示的な CSS 指定なし（ブラウザデフォルトに依存）
+- 長い単語・URLの折り返し用の `overflow-wrap` 指定なし
+- ヒーロー h1 内で `white-space: nowrap` を特定のスパンに適用
+
+**禁則対象（一般原則）**:
+- 行頭禁止: `）」』】〕〉》、。，．・：；？！`
+- 行末禁止: `（「『【〔〈《`
+
+**推奨実装**（本サイトは未適用、CJK 品質向上のため）：
+```css
+body {
+  word-break: normal;
+  overflow-wrap: break-word;
+  line-break: strict;
+}
+```
+
+### 3.7 OpenType 機能
+
+```css
+/* サイト全体設定（body タグ） */
+-webkit-font-smoothing: antialiased;  /* アンチエイリアス強制適用 */
+```
+
+- `font-feature-settings` の明示的指定なし
+- Noto Sans JP のデフォルト設定をそのまま使用
+- `antialiased` 指定により macOS/iOS での文字がやや細く表示される（意図的）
+
+**推奨実装**（本サイトは未適用）：
+```css
+body {
+  font-feature-settings: "palt" 1, "kern" 1;
+  /* palt: プロポーショナル字詰め */
+  /* kern: カーニング */
+}
+```
+
+### 3.8 縦書き
+
+- 該当なし。横書きのみ
+
+---
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary CTA（グラデーション）**
+- Background: `linear-gradient(135deg, #b82048, #d03060)`
+- Text: `#ffffff`
+- Border Radius: **0px（シャープエッジ。角丸なし）**
+- Font: Barlow Condensed 12px, weight 700
+- Letter Spacing: 0.12em
+- Text Transform: uppercase
+- Padding: 14px 36px
+- Hover: `opacity: 0.88`, `transform: translateY(-1px)`
+
+**Secondary（アウトライン・白背景用）**
+- Background: `transparent`
+- Border: `1px solid rgba(255, 255, 255, 0.25)`
+- Text: `rgba(255, 255, 255, 0.6)` → hover: `rgba(255, 255, 255, 1.0)`（色変化）
+- Border Radius: **0px**
+- Padding: 13px 28px
+- Hover Border: `1px solid #b82048`、Text: `#b82048`
+
+**Nav CTA（ナビゲーション右端）**
+- Background: `#0c0408`
+- Text: `#ffffff`
+- Font: Barlow Condensed 11px, weight 700
+- Letter Spacing: 0.12em
+- Text Transform: uppercase
+- Padding: 9px 22px
+- Border Radius: **0px**
+- Hover: `background: #b82048`
+
+**Cases / Section CTA（ブランドカラー単色）**
+- Background: `#b82048`
+- Text: `#ffffff`
+- Font: Barlow Condensed 11px, weight 700
+- Letter Spacing: 0.16em
+- Padding: 16px 44px
+- Border Radius: **0px**
+- Hover: `background: #0c0408`
+
+### Inputs
+
+- 問い合わせフォームは別ページ（`/contact`）。汎用 UI コンポーネントは以下をデフォルトとして使用
+- Border: `1px solid rgba(184, 32, 72, 0.15)` (`--bd`)
+- Border Radius: 0px（サイトポリシーに合わせてシャープ）
+- Background: `#ffffff`
+- Focus Border: `#b82048`（ブランドカラー）
+
+### Cards（Service Cards）
+
+- Background: `#ffffff`
+- Border Top: `3px solid transparent` → hover: `3px solid #b82048`
+- Border Radius: **0px**
+- Padding (body): 28px 28px 32px
+- Shadow (hover): `0 6px 32px rgba(184, 32, 72, 0.1)` — ブランドカラーティント
+- Image Height: 200px, `object-fit: cover`, `filter: brightness(0.85) saturate(0.75)` → hover 解除
+
+### Cards（NS/News Section）
+
+- Background: `#ffffff`
+- Border: `1px solid #f0f0f0`
+- Border Radius: **6px**（このカードのみ例外的に角丸あり）
+- Padding: 24px
+- Shadow: `0 6px 20px rgba(0, 0, 0, 0.05)`
+
+### Navigation
+
+- Background: `rgba(255, 255, 255, 0.95)` + `backdrop-filter: blur(16px)`
+- Border Bottom: `1px solid rgba(184, 32, 72, 0.12)`
+- Height: 64px
+- Padding: 0 52px
+- Position: fixed（スクロール追従）
+
+---
+
+## 5. Layout Principles
+
+### Spacing Scale
+
+8px ベースのスペーシング。実サイトで頻出する値:
+
+| Token | Value |
+|-------|-------|
+| XS | 4px |
+| S | 8px |
+| M | 16px |
+| L | 24px |
+| XL | 32px |
+| 2XL | 52px |
+| 3XL | 96px |
+
+### Container
+
+- Max Width: 1200px (`--container`)
+- Padding (horizontal): 52px (`--section-pad-h`)
+- Section Padding (vertical): 96px (`--section-pad-v`)
+
+### Grid
+
+- Service Cards: 3カラム, gap 2px（tight grid）
+- Cases / Works: 2カラム, gap 3px（tight grid）
+- Nav + Footer: flexbox（space-between）
+
+---
+
+## 6. Depth & Elevation
+
+| Level | Shadow | 用途 |
+|-------|--------|------|
+| 0 | none | フラットな要素（デフォルト） |
+| 1 | `0 6px 20px rgba(0,0,0,0.05)` | NS カード |
+| 2 | `0 6px 32px rgba(184,32,72,0.1)` | サービスカード・ケースカード（hover 時）、ブランドカラーティント |
+| 3 | — | 未定義（モーダル等は使用なし） |
+
+**特記**: このサイトのシャドウは通常の黒でなくブランドカラー（クリムゾン）がティントされる。UIの統一感のある設計。
+
+---
+
+## 7. Do's and Don'ts
+
+### Do（推奨）
+
+- ボタン・CTA の `border-radius` は **0px**（角丸なし）を厳守する — このサイトの最も特徴的なデザイン判断
+- 表示フォント（Barlow Condensed）は英数字・大文字ラベル・ロゴ文字列にのみ使用する
+- 日本語本文の `line-height` は `1.85` 以上を使用する（1.9 が標準）
+- カード hover 時のシャドウは `rgba(184, 32, 72, 0.1)` のブランドカラーティントにする
+- ダークセクションの背景は `#0c0408`（Ink）または `#1e0814`（Deep Ink）を使う
+- アクセントライン・区切り線には `rgba(184, 32, 72, 0.15)` のブランドカラーを使う
+- セクションタイトルの英語部分は Barlow Condensed 900 weight + uppercase で統一する
+
+### Don't（禁止）
+
+- ボタン・CTA に `border-radius` を付けない（角丸は NS/News Section カードの例外を除き使わない）
+- Barlow Condensed を日本語テキストのレンダリングに使用しない（Latin 専用フォント）
+- 純粋な黒 `#000000` をテキストカラーに使わない。必ず `#0c0408`（Ink）を使う
+- ブランドグラデーション（`#b82048` → `#d03060`）の向きを `135deg` 以外に変えない
+- 本文テキスト color を `#705060`（Mauve）より明るいグレーにしない（コントラスト不足）
+- 日本語本文に `font-weight: 400` 以上を使わない（Light = 300 が基本）
+- ダーク背景セクションのテキストに純白 `#ffffff` 以外の色を使う場合は `rgba(255,255,255,0.6)` 以上を確保する
+
+---
+
+## 8. Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | 説明 |
+|------|-------|------|
+| Mobile | ≤ 600px | スマートフォン（NS セクション変更点） |
+| Tablet/SP | ≤ 768px | タブレット・大型スマートフォン（ほとんどのグリッド変更点） |
+| Desktop | > 768px | デスクトップレイアウト |
+
+### タッチターゲット
+
+- Nav CTA ボタン: 約 38px 高さ（padding 9px × 2 + font-size 11px）
+
+### フォントサイズの調整
+
+- `clamp()` により流動的にスケール。`min(mobile)` → `max(desktop)` で自動調整
+- Hero h1: `clamp(40px, 9vw, 120px)`
+- Section display: `clamp(48px, 7vw, 88px)`
+- 本文・説明文は固定値（13–14px）でデスクトップ・モバイルとも同一
+
+### モバイルでのレイアウト変更
+
+- Section padding: `96px 52px` → `56–64px 16–20px`
+- Service cards: 3カラム → 1カラム
+- Cases grid: 2カラム → 1カラム
+- Nav: ハンバーガーメニュー化、リンクをドロワー表示
+- Band strip（サイド画像帯）: `display: none`
+
+---
+
+## 9. Agent Prompt Guide
+
+### クイックリファレンス
+
+```
+Brand Gradient: linear-gradient(135deg, #b82048, #d03060)
+Primary Color: #b82048
+Text Color (Ink): #0c0408
+Text Secondary (Mauve): #705060
+Background: #ffffff
+Background Alt: #faf3f6
+Dark Background: #0c0408
+Border Color: rgba(184, 32, 72, 0.15)
+Display Font: "Barlow Condensed", sans-serif  （英数字・ラベル用）
+Body Font: "Noto Sans JP", sans-serif         （日本語本文用）
+Body Size: 13–14px
+Body Line Height: 1.85–1.9
+Body Font Weight: 300
+Button Border Radius: 0px（角丸なし）
+```
+
+### プロンプト例
+
+```
+XECINのデザインシステムに従って、サービス紹介カードを作成してください。
+- カード背景: #ffffff
+- border-radius: 0px（角丸なし）
+- 上部ボーダー: 3px solid transparent（hover 時 #b82048）
+- hover 時 shadow: 0 6px 32px rgba(184,32,72,0.1)
+- カテゴリラベル: font-family "Barlow Condensed", font-size 12px, weight 700, letter-spacing 0.22em, color #b82048, uppercase
+- タイトル: font-family "Noto Sans JP", font-size 14px, weight 700, color #0c0408
+- 説明文: font-family "Noto Sans JP", font-size 13px, weight 300, line-height 1.85, color #705060
+- CTAボタン: background linear-gradient(135deg,#b82048,#d03060), color #fff, font-family "Barlow Condensed", font-size 12px, weight 700, letter-spacing 0.12em, uppercase, padding 14px 36px, border-radius 0
+```

--- a/design-md/xecin/preview.html
+++ b/design-md/xecin/preview.html
@@ -1,0 +1,769 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Design System Preview: XECIN</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700;900&family=Barlow+Condensed:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+<style>
+  :root {
+    /* === Brand Gradient === */
+    --gd: #b82048;
+    --gd2: #d03060;
+    --gd3: #e04878;
+    --gdl: rgba(184, 32, 72, 0.1);
+    /* === Dark (Ink) === */
+    --ink: #0c0408;
+    --ink2: #1e0814;
+    /* === Muted === */
+    --tm: #705060;
+    --ts: #4a3040;
+    /* === Backgrounds === */
+    --bg: #ffffff;
+    --bg2: #faf3f6;
+    --bg3: #f2e6ec;
+    --bg4: #ead8e0;
+    /* === Borders === */
+    --bd: rgba(184, 32, 72, 0.15);
+    --bds: rgba(184, 32, 72, 0.07);
+    /* === Fonts === */
+    --font-display: "Barlow Condensed", sans-serif;
+    --font-body: "Noto Sans JP", sans-serif;
+    /* === Elevation === */
+    --shadow-1: 0 6px 20px rgba(0,0,0,0.05);
+    --shadow-2: 0 6px 32px rgba(184,32,72,0.1);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--font-body);
+    font-size: 14px;
+    font-weight: 300;
+    line-height: 1.85;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* ============================
+     NAV
+     ============================ */
+  .nav {
+    position: sticky; top: 0; z-index: 100;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 52px; height: 64px;
+    background: rgba(255,255,255,0.95);
+    backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--bd);
+  }
+  .nav-brand {
+    font-family: var(--font-display);
+    font-weight: 900; font-size: 22px;
+    letter-spacing: 0.18em; color: var(--ink);
+    text-decoration: none;
+  }
+  .nav-brand span { color: var(--gd); }
+  .nav-links { display: flex; gap: 36px; list-style: none; }
+  .nav-links a {
+    font-size: 12px; letter-spacing: 0.07em;
+    color: var(--tm); text-decoration: none;
+  }
+  .nav-cta {
+    background: var(--ink); color: #fff;
+    font-family: var(--font-display); font-size: 11px; font-weight: 700;
+    letter-spacing: 0.12em; text-transform: uppercase;
+    padding: 9px 22px; border: none; text-decoration: none;
+  }
+
+  /* ============================
+     HERO (Dark)
+     ============================ */
+  .hero {
+    background: var(--ink2);
+    padding: 80px 52px 72px;
+    position: relative;
+    overflow: hidden;
+  }
+  .hero-bg-text {
+    position: absolute;
+    bottom: -16px; left: -8px;
+    font-family: var(--font-display); font-weight: 900;
+    font-size: 180px; line-height: 1;
+    color: rgba(255,255,255,0.04);
+    pointer-events: none; user-select: none;
+    white-space: nowrap;
+  }
+  .hero-eyebrow {
+    display: flex; align-items: center; gap: 14px;
+    margin-bottom: 28px;
+  }
+  .eyebrow-line { width: 40px; height: 1px; background: var(--gd); }
+  .eyebrow-txt {
+    font-family: var(--font-display); font-size: 11px; font-weight: 700;
+    letter-spacing: 0.22em; color: var(--gd); text-transform: uppercase;
+  }
+  .hero h1 {
+    font-family: var(--font-display); font-weight: 900;
+    font-size: 88px; line-height: 0.95;
+    color: #fff; margin-bottom: 20px;
+  }
+  .hero h1 .accent { color: var(--gd2); }
+  .hero-rule { width: 60px; height: 1px; background: var(--gd); margin: 28px 0; }
+  .hero-desc {
+    font-size: 14px; line-height: 1.9; font-weight: 300;
+    color: rgba(255,255,255,0.65); max-width: 480px;
+    border-left: 2px solid rgba(184,32,72,0.3);
+    padding-left: 16px; margin-bottom: 40px;
+  }
+  .hero-actions { display: flex; gap: 14px; align-items: center; }
+  .btn-gd {
+    background: linear-gradient(135deg, var(--gd), var(--gd2));
+    color: #fff; font-family: var(--font-display);
+    font-size: 12px; font-weight: 700;
+    letter-spacing: 0.12em; text-transform: uppercase;
+    padding: 14px 36px; border: none;
+    text-decoration: none; display: inline-block;
+    border-radius: 0;
+  }
+  .btn-wh {
+    border: 1px solid rgba(255,255,255,0.25);
+    color: rgba(255,255,255,0.6);
+    font-family: var(--font-display); font-size: 12px; font-weight: 600;
+    letter-spacing: 0.1em; text-transform: uppercase;
+    padding: 13px 28px; background: transparent;
+    text-decoration: none; display: inline-block;
+    border-radius: 0;
+  }
+  .hero-stats {
+    display: flex; gap: 0;
+    border-top: 1px solid rgba(255,255,255,0.1);
+    padding-top: 28px; margin-top: 48px;
+  }
+  .hstat {
+    padding: 0 32px 0 0; margin-right: 32px;
+    border-right: 1px solid rgba(255,255,255,0.1);
+  }
+  .hstat:last-child { border: none; margin: 0; padding: 0; }
+  .hstat-n {
+    font-family: var(--font-display); font-weight: 800; font-size: 32px;
+    line-height: 1;
+    background: linear-gradient(135deg, var(--gd), var(--gd2));
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  }
+  .hstat-l { font-size: 10px; color: rgba(255,255,255,0.4); margin-top: 3px; letter-spacing: 0.06em; }
+
+  /* ============================
+     SECTION WRAPPER
+     ============================ */
+  .section-wrap { padding: 72px 52px; }
+  .section-wrap.alt { background: var(--bg2); }
+  .section-wrap.dark { background: var(--ink); }
+  .section-inner { max-width: 1100px; margin: 0 auto; }
+
+  .sec-label {
+    font-family: var(--font-display); font-size: 10px; font-weight: 700;
+    letter-spacing: 0.22em; color: var(--gd); text-transform: uppercase;
+    display: flex; align-items: center; gap: 10px; margin-bottom: 16px;
+  }
+  .sec-label::before { content: ""; width: 24px; height: 1px; background: var(--gd); }
+  .sec-title {
+    font-family: var(--font-display); font-weight: 900;
+    font-size: 56px; letter-spacing: -0.01em; line-height: 1;
+    color: var(--ink); margin-bottom: 8px;
+  }
+  .sec-title .accent { color: var(--gd); }
+  .sec-title.light { color: #fff; }
+  .sec-sub {
+    font-size: 13px; color: var(--tm); font-weight: 300;
+    letter-spacing: 0.08em; margin-bottom: 48px;
+  }
+  .sec-rule { width: 40px; height: 1px; background: var(--gd); margin: 14px 0 40px; }
+
+  /* ============================
+     COLOR PALETTE
+     ============================ */
+  .color-group-label {
+    font-size: 11px; font-weight: 700; color: var(--ts);
+    text-transform: uppercase; letter-spacing: 0.1em;
+    margin: 28px 0 12px;
+  }
+  .color-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 10px; margin-bottom: 16px;
+  }
+  .color-swatch { overflow: hidden; background: var(--bg); box-shadow: var(--shadow-1); }
+  .color-block { height: 64px; width: 100%; }
+  .color-info { padding: 10px 12px; }
+  .color-name { font-size: 12px; font-weight: 700; margin-bottom: 2px; color: var(--ink); }
+  .color-hex { font-size: 11px; color: var(--tm); font-family: monospace; }
+  .color-role { font-size: 11px; color: var(--tm); margin-top: 2px; }
+
+  /* ============================
+     TYPOGRAPHY
+     ============================ */
+  .type-row { margin-bottom: 32px; padding-bottom: 28px; border-bottom: 1px solid var(--bd); }
+  .type-meta { font-size: 11px; color: var(--tm); margin-bottom: 8px; font-family: monospace; }
+  .type-hero {
+    font-family: var(--font-display); font-weight: 900;
+    font-size: 80px; line-height: 0.95; color: var(--ink);
+  }
+  .type-section-display {
+    font-family: var(--font-display); font-weight: 900;
+    font-size: 64px; letter-spacing: -0.01em; line-height: 1; color: var(--ink);
+  }
+  .type-band-h2 {
+    font-family: var(--font-display); font-weight: 900;
+    font-size: 48px; line-height: 1.1; letter-spacing: -0.01em; color: var(--ink);
+  }
+  .type-step-title {
+    font-family: var(--font-body); font-weight: 900;
+    font-size: 20px; letter-spacing: -0.01em; color: var(--ink);
+  }
+  .type-body-faq {
+    font-family: var(--font-body); font-weight: 700;
+    font-size: 15px; line-height: 1.5; color: var(--ink);
+  }
+  .type-body {
+    font-family: var(--font-body); font-weight: 300;
+    font-size: 13px; line-height: 1.85; color: var(--tm);
+  }
+  .type-caption {
+    font-family: var(--font-body); font-weight: 300;
+    font-size: 12px; letter-spacing: 0.07em; color: var(--tm);
+  }
+  .type-label {
+    font-family: var(--font-display); font-weight: 700;
+    font-size: 11px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--gd);
+  }
+
+  /* ============================
+     COMPONENTS — BUTTONS
+     ============================ */
+  .btn-row { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; margin-bottom: 16px; }
+
+  .btn-nav-cta {
+    background: var(--ink); color: #fff;
+    font-family: var(--font-display); font-size: 11px; font-weight: 700;
+    letter-spacing: 0.12em; text-transform: uppercase;
+    padding: 9px 22px; border: none; border-radius: 0;
+    text-decoration: none; display: inline-block;
+  }
+  .btn-primary-lg {
+    background: linear-gradient(135deg, var(--gd), var(--gd2));
+    color: #fff; font-family: var(--font-display); font-size: 12px; font-weight: 700;
+    letter-spacing: 0.12em; text-transform: uppercase;
+    padding: 14px 36px; border: none; border-radius: 0;
+    text-decoration: none; display: inline-block;
+  }
+  .btn-section-cta {
+    background: var(--gd); color: #fff;
+    font-family: var(--font-display); font-size: 11px; font-weight: 700;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    padding: 16px 44px; border: none; border-radius: 0;
+    text-decoration: none; display: inline-block;
+  }
+  .btn-dark-bg-secondary {
+    border: 1px solid rgba(255,255,255,0.25);
+    color: rgba(255,255,255,0.6);
+    font-family: var(--font-display); font-size: 12px; font-weight: 600;
+    letter-spacing: 0.1em; text-transform: uppercase;
+    padding: 13px 28px; background: transparent; border-radius: 0;
+    text-decoration: none; display: inline-block;
+  }
+
+  /* ============================
+     COMPONENTS — CARDS
+     ============================ */
+  .card-grid {
+    display: grid; grid-template-columns: repeat(3, 1fr);
+    gap: 2px; background: var(--bg3);
+  }
+  .scard {
+    background: var(--bg);
+    border-top: 3px solid transparent;
+    transition: border-top-color 0.3s, box-shadow 0.3s;
+    overflow: hidden;
+  }
+  .scard:hover {
+    border-top-color: var(--gd);
+    box-shadow: 0 6px 32px rgba(184,32,72,0.1);
+  }
+  .scard-img {
+    width: 100%; height: 160px;
+    object-fit: cover;
+    background: var(--bg3);
+    display: block;
+    filter: brightness(0.85) saturate(0.75);
+  }
+  .scard-img-placeholder {
+    width: 100%; height: 160px;
+    background: linear-gradient(135deg, var(--bg3), var(--bg4));
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--font-display); font-size: 13px; font-weight: 700;
+    letter-spacing: 0.1em; color: var(--gd); text-transform: uppercase;
+  }
+  .scard-body { padding: 24px 24px 28px; }
+  .scard-num {
+    font-family: var(--font-display); font-size: 12px; font-weight: 700;
+    letter-spacing: 0.22em; color: var(--gd); text-transform: uppercase;
+    margin-bottom: 8px; display: block;
+  }
+  .scard-title {
+    font-size: 14px; font-weight: 700; color: var(--ink);
+    margin-bottom: 8px; line-height: 1.4;
+  }
+  .scard-body-txt {
+    font-size: 13px; line-height: 1.85; color: var(--tm); font-weight: 300;
+  }
+  .scard-tag {
+    display: inline-block; margin-top: 12px;
+    font-family: var(--font-display); font-size: 11px; font-weight: 700;
+    letter-spacing: 0.16em; color: var(--gd);
+    border-bottom: 1px solid rgba(184,32,72,0.3);
+    padding-bottom: 2px; text-transform: uppercase;
+  }
+
+  /* ============================
+     COMPONENTS — ELEVATION
+     ============================ */
+  .shadow-row { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px; }
+  .shadow-box {
+    width: 200px; height: 100px;
+    background: var(--bg);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .shadow-box-label { font-size: 11px; color: var(--tm); font-family: monospace; text-align: center; }
+
+  /* ============================
+     SPACING
+     ============================ */
+  .spacing-row { display: flex; gap: 8px; flex-wrap: wrap; align-items: flex-end; margin-top: 8px; }
+  .spacing-item { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+  .spacing-block { background: linear-gradient(135deg, var(--gd), var(--gd2)); border-radius: 0; width: 36px; }
+  .spacing-label { font-size: 10px; color: var(--tm); font-family: monospace; }
+
+  /* ============================
+     NAVIGATION DEMO
+     ============================ */
+  .component-label {
+    font-size: 11px; color: var(--tm); font-family: monospace;
+    margin-bottom: 8px; padding: 4px 8px; background: var(--bg3);
+    display: inline-block;
+  }
+
+  /* ============================
+     AGENT QUICK REF
+     ============================ */
+  .quick-ref {
+    background: var(--ink); color: rgba(255,255,255,0.8);
+    padding: 32px 36px; border-left: 3px solid var(--gd);
+    margin-top: 16px;
+  }
+  .quick-ref pre {
+    font-family: monospace; font-size: 12px; line-height: 1.8;
+    color: rgba(255,255,255,0.85); white-space: pre-wrap;
+  }
+  .quick-ref-title {
+    font-family: var(--font-display); font-size: 13px; font-weight: 700;
+    letter-spacing: 0.18em; text-transform: uppercase; color: var(--gd);
+    margin-bottom: 16px;
+  }
+</style>
+</head>
+<body>
+
+<!-- ============================
+     NAVIGATION
+     ============================ -->
+<nav class="nav">
+  <a href="#" class="nav-brand">XE<span>C</span>IN</a>
+  <ul class="nav-links">
+    <li><a href="#">サービス</a></li>
+    <li><a href="#">実績</a></li>
+    <li><a href="#">会社概要</a></li>
+    <li><a href="#">Tech Blog</a></li>
+    <li><a href="#">お問い合わせ</a></li>
+  </ul>
+  <a href="#" class="nav-cta">無料相談はこちら</a>
+</nav>
+
+<!-- ============================
+     HERO (Dark Section)
+     ============================ -->
+<section class="hero">
+  <div class="hero-bg-text">LAB DEVELOPMENT</div>
+  <div class="hero-eyebrow">
+    <div class="eyebrow-line"></div>
+    <span class="eyebrow-txt">XECIN Lab-Type Development</span>
+  </div>
+  <h1>途中から<br><span class="accent">ゴールまで</span><br>伴走する</h1>
+  <div class="hero-rule"></div>
+  <p class="hero-desc">
+    どんな状況でもご相談ください。部分開発なら途中から少数精鋭チームが参画し、プロジェクトを前に進めます。
+  </p>
+  <div class="hero-actions">
+    <a href="#" class="btn-gd">無料相談はこちら</a>
+    <a href="#" class="btn-wh">サービスを見る</a>
+  </div>
+  <div class="hero-stats">
+    <div class="hstat">
+      <div class="hstat-n">2W</div>
+      <div class="hstat-l">最短着手まで</div>
+    </div>
+    <div class="hstat">
+      <div class="hstat-n">0円</div>
+      <div class="hstat-l">追加見積もりなし</div>
+    </div>
+    <div class="hstat">
+      <div class="hstat-n">100%</div>
+      <div class="hstat-l">上流から保守まで</div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================
+     COLOR PALETTE
+     ============================ -->
+<div class="section-wrap">
+  <div class="section-inner">
+    <div class="sec-label">Color Palette</div>
+    <div class="sec-rule"></div>
+
+    <div class="color-group-label">Brand Gradient</div>
+    <div class="color-grid">
+      <div class="color-swatch">
+        <div class="color-block" style="background:#b82048;"></div>
+        <div class="color-info">
+          <div class="color-name">Crimson</div>
+          <div class="color-hex">#b82048</div>
+          <div class="color-role">--gd: グラデーション開始・アクセント</div>
+        </div>
+      </div>
+      <div class="color-swatch">
+        <div class="color-block" style="background:#d03060;"></div>
+        <div class="color-info">
+          <div class="color-name">Rose</div>
+          <div class="color-hex">#d03060</div>
+          <div class="color-role">--gd2: グラデーション終了・アクセント</div>
+        </div>
+      </div>
+      <div class="color-swatch">
+        <div class="color-block" style="background:#e04878;"></div>
+        <div class="color-info">
+          <div class="color-name">Light Rose</div>
+          <div class="color-hex">#e04878</div>
+          <div class="color-role">--gd3: 明るいグラデーション段階</div>
+        </div>
+      </div>
+      <div class="color-swatch">
+        <div class="color-block" style="background:linear-gradient(135deg,#b82048,#d03060);"></div>
+        <div class="color-info">
+          <div class="color-name">Brand Gradient</div>
+          <div class="color-hex">135deg →</div>
+          <div class="color-role">CTAボタン・見出しアクセント</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="color-group-label">Dark (Ink)</div>
+    <div class="color-grid">
+      <div class="color-swatch">
+        <div class="color-block" style="background:#0c0408;"></div>
+        <div class="color-info">
+          <div class="color-name">Ink</div>
+          <div class="color-hex">#0c0408</div>
+          <div class="color-role">--ink: 本文テキスト・ナビ背景</div>
+        </div>
+      </div>
+      <div class="color-swatch">
+        <div class="color-block" style="background:#1e0814;"></div>
+        <div class="color-info">
+          <div class="color-name">Deep Ink</div>
+          <div class="color-hex">#1e0814</div>
+          <div class="color-role">--ink2: ヒーロー背景・フッター</div>
+        </div>
+      </div>
+      <div class="color-swatch">
+        <div class="color-block" style="background:#705060;"></div>
+        <div class="color-info">
+          <div class="color-name">Mauve</div>
+          <div class="color-hex">#705060</div>
+          <div class="color-role">--tm: 補足テキスト・説明文</div>
+        </div>
+      </div>
+      <div class="color-swatch">
+        <div class="color-block" style="background:#4a3040;"></div>
+        <div class="color-info">
+          <div class="color-name">Dark Mauve</div>
+          <div class="color-hex">#4a3040</div>
+          <div class="color-role">--ts: 濃いセカンダリテキスト</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="color-group-label">Background Scale</div>
+    <div class="color-grid">
+      <div class="color-swatch">
+        <div class="color-block" style="background:#ffffff; border:1px solid #eee;"></div>
+        <div class="color-info">
+          <div class="color-name">White</div>
+          <div class="color-hex">#ffffff</div>
+          <div class="color-role">--bg: メイン背景</div>
+        </div>
+      </div>
+      <div class="color-swatch">
+        <div class="color-block" style="background:#faf3f6;"></div>
+        <div class="color-info">
+          <div class="color-name">Rose 50</div>
+          <div class="color-hex">#faf3f6</div>
+          <div class="color-role">--bg2: ライトセクション背景</div>
+        </div>
+      </div>
+      <div class="color-swatch">
+        <div class="color-block" style="background:#f2e6ec;"></div>
+        <div class="color-info">
+          <div class="color-name">Rose 100</div>
+          <div class="color-hex">#f2e6ec</div>
+          <div class="color-role">--bg3: カード間ギャップ・区切り</div>
+        </div>
+      </div>
+      <div class="color-swatch">
+        <div class="color-block" style="background:#ead8e0;"></div>
+        <div class="color-info">
+          <div class="color-name">Rose 200</div>
+          <div class="color-hex">#ead8e0</div>
+          <div class="color-role">--bg4: 濃いサーフェス</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================
+     TYPOGRAPHY
+     ============================ -->
+<div class="section-wrap alt">
+  <div class="section-inner">
+    <div class="sec-label">Typography</div>
+    <div class="sec-rule"></div>
+
+    <div class="type-row">
+      <div class="type-meta">Hero H1 — Barlow Condensed 900, clamp(40px, 9vw, 120px), line-height: 0.95</div>
+      <div class="type-hero">LAB<br>DEVELOPMENT</div>
+    </div>
+
+    <div class="type-row">
+      <div class="type-meta">Section Display — Barlow Condensed 900, clamp(48px, 7vw, 88px), letter-spacing: -0.01em, line-height: 1</div>
+      <div class="type-section-display">OUR <span style="color:var(--gd)">SERVICE</span></div>
+    </div>
+
+    <div class="type-row">
+      <div class="type-meta">Band H2 — Barlow Condensed 900, clamp(28px, 4.5vw, 56px), line-height: 1.1</div>
+      <div class="type-band-h2">技術で勝負する、<br><span style="color:var(--gd2)">現場主義</span>の会社</div>
+    </div>
+
+    <div class="type-row">
+      <div class="type-meta">Step / Case Title — Noto Sans JP 900, 20px, letter-spacing: -0.01em</div>
+      <div class="type-step-title">途中参画OKで最短2週間で着手</div>
+    </div>
+
+    <div class="type-row">
+      <div class="type-meta">FAQ / Body H3 — Noto Sans JP 700, 15px, line-height: 1.5</div>
+      <div class="type-body-faq">今のチームだけでは回らないが、外注先を乗り換えたくない場合は？</div>
+    </div>
+
+    <div class="type-row">
+      <div class="type-meta">Body — Noto Sans JP 300, 13–14px, line-height: 1.85–1.9, color: #705060</div>
+      <div class="type-body">プロジェクトの途中からでもご相談ください。部分開発なら途中から少数精鋭チームが参画し、メンバーを固定してもらえれば業務理解が深まり、開発スピードが向上します。</div>
+    </div>
+
+    <div class="type-row">
+      <div class="type-meta">Caption / Nav — Noto Sans JP 300–400, 12px, letter-spacing: 0.07–0.08em</div>
+      <div class="type-caption">サービス　実績　会社概要　Tech Blog　お問い合わせ</div>
+    </div>
+
+    <div class="type-row" style="border-bottom:none; margin-bottom:0; padding-bottom:0;">
+      <div class="type-meta">Label / Eyebrow — Barlow Condensed 700, 10–12px, letter-spacing: 0.16–0.22em, UPPERCASE, color: #b82048</div>
+      <div class="type-label">XECIN Lab-Type Development　　OUR SERVICE　　MID-PROJECT ENTRY WELCOME</div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================
+     COMPONENTS — BUTTONS
+     ============================ -->
+<div class="section-wrap">
+  <div class="section-inner">
+    <div class="sec-label">Buttons</div>
+    <div class="sec-rule"></div>
+
+    <div class="component-label">Primary CTA (gradient) — border-radius: 0, padding: 14px 36px</div>
+    <div class="btn-row" style="margin-top:8px;">
+      <a class="btn-primary-lg">無料相談はこちら</a>
+      <a class="btn-section-cta">実績をすべて見る</a>
+      <a class="btn-nav-cta">無料相談はこちら</a>
+    </div>
+
+    <div style="background:var(--ink); padding:28px 24px; margin-top:24px;">
+      <div class="component-label" style="background:rgba(255,255,255,0.1); color:rgba(255,255,255,0.6);">Dark background — Secondary button</div>
+      <div class="btn-row" style="margin-top:12px;">
+        <a class="btn-gd">無料相談はこちら</a>
+        <a class="btn-wh">サービスを見る</a>
+      </div>
+    </div>
+
+    <div style="margin-top:24px; padding:16px; background:var(--bg3); font-size:12px; color:var(--ts);">
+      ⚠️ 全ボタン・CTAの <strong>border-radius は 0px（角丸なし）</strong>。これはブランドの最重要デザインポリシー。
+    </div>
+  </div>
+</div>
+
+<!-- ============================
+     COMPONENTS — CARDS
+     ============================ -->
+<div class="section-wrap alt">
+  <div class="section-inner">
+    <div class="sec-label">Service Cards</div>
+    <div class="sec-rule"></div>
+
+    <div class="card-grid">
+      <div class="scard">
+        <div class="scard-img-placeholder">IMG 200px</div>
+        <div class="scard-body">
+          <span class="scard-num">● 01</span>
+          <div class="scard-title">途中参画OKで最短2週間で着手</div>
+          <div class="scard-body-txt">プロジェクトの途中からでもご相談可能。ご相談から最短2週間でチームを編成し、開発に着手します。</div>
+          <div class="scard-tag">Mid-project entry welcome</div>
+        </div>
+      </div>
+      <div class="scard" style="border-top-color:var(--gd); box-shadow:0 6px 32px rgba(184,32,72,0.1);">
+        <div class="scard-img-placeholder">HOVER STATE</div>
+        <div class="scard-body">
+          <span class="scard-num">● 02</span>
+          <div class="scard-title">少数精鋭チームがゴールまで伴走</div>
+          <div class="scard-body-txt">プロジェクト専任のチームを編成。メンバーを固定してもらえれば業務理解が深まり、開発スピードが向上します。</div>
+          <div class="scard-tag">Dedicated team</div>
+        </div>
+      </div>
+      <div class="scard">
+        <div class="scard-img-placeholder">IMG 200px</div>
+        <div class="scard-body">
+          <span class="scard-num">● 03</span>
+          <div class="scard-title">上流から上流まで一貫支援</div>
+          <div class="scard-body-txt">要件整理・設計から開発・テスト、保守運用まで一貫して対応。作りたいものを一緒に整理します。</div>
+          <div class="scard-tag">End-to-end support</div>
+        </div>
+      </div>
+    </div>
+    <div style="margin-top:16px; padding:12px; background:var(--bg3); font-size:12px; color:var(--ts);">
+      カード border-top: 3px solid transparent → hover 時: <strong>#b82048</strong>。shadow も rgba(184,32,72, 0.1) のブランドカラーティント。
+    </div>
+  </div>
+</div>
+
+<!-- ============================
+     ELEVATION & SPACING
+     ============================ -->
+<div class="section-wrap">
+  <div class="section-inner">
+    <div class="sec-label">Elevation & Spacing</div>
+    <div class="sec-rule"></div>
+
+    <div class="component-label">Shadow Levels</div>
+    <div class="shadow-row" style="margin-bottom:40px;">
+      <div>
+        <div class="shadow-box" style="box-shadow:none; border:1px solid var(--bd);">
+          <div class="shadow-box-label">Level 0<br>none</div>
+        </div>
+        <div style="font-size:11px; color:var(--tm); margin-top:6px; font-family:monospace;">フラット要素</div>
+      </div>
+      <div>
+        <div class="shadow-box" style="box-shadow:var(--shadow-1);">
+          <div class="shadow-box-label">Level 1<br>0 6px 20px<br>rgba(0,0,0,.05)</div>
+        </div>
+        <div style="font-size:11px; color:var(--tm); margin-top:6px; font-family:monospace;">NSカード</div>
+      </div>
+      <div>
+        <div class="shadow-box" style="box-shadow:var(--shadow-2);">
+          <div class="shadow-box-label">Level 2<br>0 6px 32px<br>rgba(184,32,72,.1)</div>
+        </div>
+        <div style="font-size:11px; color:var(--tm); margin-top:6px; font-family:monospace;">カード hover</div>
+      </div>
+    </div>
+
+    <div class="component-label">Spacing Scale (8px base)</div>
+    <div class="spacing-row">
+      <div class="spacing-item">
+        <div class="spacing-block" style="height:4px;"></div>
+        <div class="spacing-label">XS<br>4px</div>
+      </div>
+      <div class="spacing-item">
+        <div class="spacing-block" style="height:8px;"></div>
+        <div class="spacing-label">S<br>8px</div>
+      </div>
+      <div class="spacing-item">
+        <div class="spacing-block" style="height:16px;"></div>
+        <div class="spacing-label">M<br>16px</div>
+      </div>
+      <div class="spacing-item">
+        <div class="spacing-block" style="height:24px;"></div>
+        <div class="spacing-label">L<br>24px</div>
+      </div>
+      <div class="spacing-item">
+        <div class="spacing-block" style="height:32px;"></div>
+        <div class="spacing-label">XL<br>32px</div>
+      </div>
+      <div class="spacing-item">
+        <div class="spacing-block" style="height:52px;"></div>
+        <div class="spacing-label">2XL<br>52px</div>
+      </div>
+      <div class="spacing-item">
+        <div class="spacing-block" style="height:96px;"></div>
+        <div class="spacing-label">3XL<br>96px</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================
+     AGENT QUICK REF
+     ============================ -->
+<div class="section-wrap dark">
+  <div class="section-inner">
+    <div class="sec-label" style="color:var(--gd);">Agent Quick Reference</div>
+    <div class="sec-rule"></div>
+    <div class="quick-ref">
+      <div class="quick-ref-title">XECIN Design Token Quick Ref</div>
+      <pre>
+Brand Gradient : linear-gradient(135deg, #b82048, #d03060)
+Primary        : #b82048   (--gd)
+Rose           : #d03060   (--gd2)
+Ink (Text)     : #0c0408   (--ink)
+Deep Ink (BG)  : #1e0814   (--ink2)
+Mauve (Sub)    : #705060   (--tm)
+White (BG)     : #ffffff   (--bg)
+Rose BG        : #faf3f6   (--bg2)
+Border         : rgba(184, 32, 72, 0.15)   (--bd)
+
+Display Font   : "Barlow Condensed", sans-serif   → 英数字・ラベル専用
+Body Font      : "Noto Sans JP", sans-serif        → 日本語本文
+
+Body Size      : 13–14px
+Body Weight    : 300 (Light)
+Body LineH     : 1.85–1.9
+Label Tracking : 0.22em (uppercase labels)
+Body Tracking  : 0.07–0.08em
+
+Button Radius  : 0px — 必須。角丸は絶対に付けない
+Card Shadow    : 0 6px 32px rgba(184,32,72,0.1)   ← ブランドカラーティント
+Section Pad    : 96px vertical / 52px horizontal
+Container      : 1200px max-width</pre>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Add: xecin.jp (Web Development Lab)

XECIN は東京の少数精鋭ラボ型 Web 開発スタジオです。コーポレートサイト xecin.jp の DESIGN.md
を寄稿します。本家テンプレート 9 セクション構成 + 日本語タイポグラフィ拡張（3.1–3.8）に完全準拠しています。

### Site Overview
- **Domain**: https://xecin.jp/
- **Category**: Web Development Lab
- **Tech Stack**: Astro（静的ビルド）
- **Design DNA**: シャープエッジ（border-radius 0px 厳守） + クリムゾングラデーション

### Files Added
- `design-md/xecin/DESIGN.md`（本家テンプレ 9 セクション、CJK 拡張推奨実装含む）
- `design-md/xecin/preview.html`
- README.md の Included Sites テーブル末尾に 1 行追記

### Compliance
- Template 9 sections + Typography 3.1–3.8 完全準拠
- 「Headers in English, values in Japanese」
- Extracted from publicly available CSS（Disclaimer 適合）
- MIT-licensed contribution

[VoltAgent/awesome-design-md](https://github.com/VoltAgent/awesome-design-md) と本家リポジトリの構想に感謝します。
レビュー・フィードバックを歓迎します。